### PR TITLE
Updating the version of the ttt-core gem used, and integrating with CI

### DIFF
--- a/.coveralls.yml
+++ b/.coveralls.yml
@@ -1,0 +1,2 @@
+repo_token: ilfrmXjw4sWQbQwONjy8sa48BVgzAe26j
+service_name: travis-ci

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,1 @@
+language: ruby

--- a/Gemfile
+++ b/Gemfile
@@ -2,12 +2,13 @@ source 'https://rubygems.org'
 
 gem 'sinatra', '1.4.6'
 gem 'thin', '1.6.4'
-gem 'ttt-core', '0.0.1'
+gem 'ttt-core', '1.0.0'
 
 group :test do
   gem 'rack-test', '0.6.3'
   gem 'rake', '10.5.0'
   gem 'rspec', '3.4.0', :require => 'spec'
   gem 'simplecov', '0.11.1'
+  gem 'coveralls', '0.8.10'
   gem 'nokogiri', '1.6.7.2'
 end

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,12 +1,25 @@
 GEM
   remote: https://rubygems.org/
   specs:
+    coveralls (0.8.10)
+      json (~> 1.8)
+      rest-client (>= 1.6.8, < 2)
+      simplecov (~> 0.11.0)
+      term-ansicolor (~> 1.3)
+      thor (~> 0.19.1)
+      tins (~> 1.6.0)
     daemons (1.2.3)
     diff-lcs (1.2.5)
     docile (1.1.5)
+    domain_name (0.5.20160128)
+      unf (>= 0.0.5, < 1.0.0)
     eventmachine (1.0.9.1)
+    http-cookie (1.0.2)
+      domain_name (~> 0.5)
     json (1.8.3)
+    mime-types (2.99)
     mini_portile2 (2.0.0)
+    netrc (0.11.0)
     nokogiri (1.6.7.2)
       mini_portile2 (~> 2.0.0.rc2)
     rack (1.6.4)
@@ -15,6 +28,10 @@ GEM
     rack-test (0.6.3)
       rack (>= 1.0)
     rake (10.5.0)
+    rest-client (1.8.0)
+      http-cookie (>= 1.0.2, < 2.0)
+      mime-types (>= 1.16, < 3.0)
+      netrc (~> 0.7)
     rspec (3.4.0)
       rspec-core (~> 3.4.0)
       rspec-expectations (~> 3.4.0)
@@ -37,17 +54,25 @@ GEM
       rack (~> 1.4)
       rack-protection (~> 1.4)
       tilt (>= 1.3, < 3)
+    term-ansicolor (1.3.2)
+      tins (~> 1.0)
     thin (1.6.4)
       daemons (~> 1.0, >= 1.0.9)
       eventmachine (~> 1.0, >= 1.0.4)
       rack (~> 1.0)
+    thor (0.19.1)
     tilt (2.0.2)
-    ttt-core (0.0.1)
+    tins (1.6.0)
+    ttt-core (1.0.0)
+    unf (0.1.4)
+      unf_ext
+    unf_ext (0.0.7.1)
 
 PLATFORMS
   ruby
 
 DEPENDENCIES
+  coveralls (= 0.8.10)
   nokogiri (= 1.6.7.2)
   rack-test (= 0.6.3)
   rake (= 10.5.0)
@@ -55,7 +80,7 @@ DEPENDENCIES
   simplecov (= 0.11.1)
   sinatra (= 1.4.6)
   thin (= 1.6.4)
-  ttt-core (= 0.0.1)
+  ttt-core (= 1.0.0)
 
 BUNDLED WITH
    1.11.2

--- a/README.md
+++ b/README.md
@@ -1,5 +1,7 @@
 # Sinatra Web Application for Tic Tac Toe
 
+[![Build Status](https://travis-ci.org/gemcfadyen/Apprenticeship-RubyWebTicTacToe.svg?branch=master)](https://travis-ci.org/gemcfadyen/Apprenticeship-RubyWebTicTacToe)   [![Coverage Status](https://coveralls.io/repos/github/gemcfadyen/Apprenticeship-RubyWebTicTacToe/badge.svg?branch=master)](https://coveralls.io/github/gemcfadyen/Apprenticeship-RubyWebTicTacToe?branch=master)
+
 To play Tic Tac Toe through a browser, clone the repository into a folder
 >> git clone git@github.com:gemcfadyen/Apprenticeship-RubyWebTicTacToe.git
 

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -17,8 +17,17 @@
 #
 # See http://rubydoc.info/gems/rspec-core/RSpec/Core/Configuration
 
+require 'coveralls'
 require 'simplecov'
+
 SimpleCov.start
+SimpleCov.minimum_coverage 100
+Coveralls.wear!
+
+SimpleCov.formatter = SimpleCov::Formatter::MultiFormatter.new([
+    SimpleCov::Formatter::HTMLFormatter,
+      Coveralls::SimpleCov::Formatter
+])
 
 lib = File.expand_path("../../lib", __FILE__)
 $:.unshift(lib)


### PR DESCRIPTION
@jsuchy @ecomba 

Upgrading the web app repository to use the published version of the ttt-core gem, and integrated into CI (travis and coveralls for code coverage).
