### PR TITLE
Moves css into css folder

### DIFF
--- a/lib/web_ttt_controller.rb
+++ b/lib/web_ttt_controller.rb
@@ -10,7 +10,7 @@ require 'web_tic_tac_toe'
 class WebTTTController < Sinatra::Base
   set :views, File.dirname(__FILE__) + '/../views'
   set :public_folder, File.dirname(__FILE__) + '/../public'
-#  set :css_dir, File.dirname(__FILE__) + '/../public/css'
+  set :css_dir, File.dirname(__FILE__) + '/../public/css'
   enable :sessions
 
   get '/' do

--- a/public/css/theme.css
+++ b/public/css/theme.css
@@ -1,5 +1,5 @@
 body {
-  background-image: url("background.jpg");
+  background-image: url("../background.jpg");
   text-align: center;
 }
 
@@ -29,6 +29,7 @@ table, tr, td {
 td {
   width: 150px;
   height: 150px;
+  font-size: 2em;
 }
 
 a {
@@ -38,7 +39,7 @@ a {
   height: 100%;
   width: 100%;
   display: flex;
-  align-items:center;
+  align-items: center;
   justify-content: center;
 }
 

--- a/views/game.erb
+++ b/views/game.erb
@@ -3,7 +3,7 @@
   <head>
     <meta charset='UTF-8' />
     <title>Tic Tac Toe</title>
-    <link rel='stylesheet' type='text/css' href="/theme.css"/>
+    <link rel='stylesheet' type='text/css' href="/css/theme.css"/>
   </head>
 
   <body>

--- a/views/player_options.erb
+++ b/views/player_options.erb
@@ -3,7 +3,7 @@
   <head>
     <meta charset='UTF-8' />
     <title>Tic Tac Toe</title>
-    <link rel='stylesheet' type='text/css' href="/theme.css" />
+    <link rel='stylesheet' type='text/css' href="/css/theme.css" />
   </head>
   <body>
     <h1>Welcome To Tic Tac Toe


### PR DESCRIPTION
@ecomba @jsuchy

Second attempt at moving css into it's own folder, to make the layout agree with the usual folder structures.

The paths on the erb templates were updated to point to public/css, and the path to the background image was also updated in the css config.
